### PR TITLE
GitHub publishing

### DIFF
--- a/.github/workflows/package_release.yaml
+++ b/.github/workflows/package_release.yaml
@@ -1,0 +1,20 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Publish package
+        run: gradle publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,16 @@ plugins {
     // shadowJar plugin to build fat jar
     id 'com.github.johnrengelman.shadow' version '6.1.0'
 
+    // Plugin to publish artifacts to github and maven
+    id 'maven-publish'
+
 }
+
+sourceCompatibility = JavaVersion.VERSION_11
+
+group 'org.minima'
+version '0.98.15'
+
 
 repositories {
     // Use jcenter for resolving dependencies.
@@ -81,4 +90,20 @@ jar {
         attributes 'Main-Class': 'org.minima.Start'
     }
 }
-
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/1mprobable/Minima"
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            from(components.java)
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/1mprobable/Minima"
+            url = "https://maven.pkg.github.com/minima-global/Minima"
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")


### PR DESCRIPTION
Fixes MiniDroid repo has a manually coped version of the minima code.

## Proposed Changes

  - Publish Minima release artefacts for use in MiniDroid
  - Add a github workflow to automate this upon creating a release
  - See corresponding PR in the MiniDroid repo

