### PR TITLE
Nanohttpd Secure Connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@
 
 # Ignore Gradle build output directory
 build
+# Ignore the java docs directory
+docs
 
 # ignore IDE config and use instead the following command to re-generate them correctly: ./gradlew cleanEclipse eclipse 
 .settings/*
 .vscode/*
+.idea/*
 .settings/org.eclipse.buildship.core.prefs
 .settings/org.eclipse.jdt.core.prefs
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ plugins {
 repositories {
     // Use jcenter for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
+    mavenCentral()
     jcenter()
 }
 
@@ -45,7 +46,8 @@ dependencies {
 //    implementation group: 'com.h2database', name: 'h2', version: '1.4.200'
 
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.25'
-    
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.68'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.68'
 }
 
 sourceSets {

--- a/src/org/minima/system/network/minidapps/SelfSignedCertGenerator.java
+++ b/src/org/minima/system/network/minidapps/SelfSignedCertGenerator.java
@@ -1,0 +1,115 @@
+package org.minima.system.network.minidapps;
+
+import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.*;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509ExtensionUtils;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.bc.BcDigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * Utility class for generating self-signed certificates.
+ */
+public final class SelfSignedCertGenerator {
+
+    public static final String CERTIFICATE_ALIAS = "MINIMA_NODE";
+    public static final String CERTIFICATE_NAME = "minima.keystore";
+
+    private SelfSignedCertGenerator() {
+    }
+
+    /**
+     * Generates a self signed certificate using the BouncyCastle lib.
+     *
+     * @param keyPair       used for signing the certificate with PrivateKey
+     * @param hashAlgorithm Hash function
+     * @param cn            Common Name to be used in the subject dn
+     * @param days          validity period in days of the certificate
+     * @return self-signed X509Certificate
+     * @throws OperatorCreationException on creating a key id
+     * @throws CertIOException           on building JcaContentSignerBuilder
+     * @throws CertificateException      on getting certificate from provider
+     */
+    public static X509Certificate generate(final KeyPair keyPair,
+                                           final String hashAlgorithm,
+                                           final String cn,
+                                           final int days)
+            throws OperatorCreationException, CertificateException, CertIOException {
+        final Instant now = Instant.now();
+        final Date notBefore = Date.from(now);
+        final Date notAfter = Date.from(now.plus(Duration.ofDays(days)));
+
+        final ContentSigner contentSigner = new JcaContentSignerBuilder(hashAlgorithm).build(keyPair.getPrivate());
+        final X500Name x500Name = new X500Name("CN=" + cn);
+        final X509v3CertificateBuilder certificateBuilder =
+                new JcaX509v3CertificateBuilder(x500Name,
+                        BigInteger.valueOf(now.toEpochMilli()),
+                        notBefore,
+                        notAfter,
+                        x500Name,
+                        keyPair.getPublic())
+                        .addExtension(Extension.subjectKeyIdentifier, false, createSubjectKeyId(keyPair.getPublic()))
+                        .addExtension(Extension.authorityKeyIdentifier, false, createAuthorityKeyId(keyPair.getPublic()))
+                        .addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+
+        return new JcaX509CertificateConverter()
+                .setProvider(new BouncyCastleProvider()).getCertificate(certificateBuilder.build(contentSigner));
+    }
+
+    /**
+     * Creates the hash value of the public key.
+     *
+     * @param publicKey of the certificate
+     * @return SubjectKeyIdentifier hash
+     * @throws OperatorCreationException
+     */
+    private static SubjectKeyIdentifier createSubjectKeyId(final PublicKey publicKey) throws OperatorCreationException {
+        final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
+        final DigestCalculator digCalc =
+                new BcDigestCalculatorProvider().get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+
+        return new X509ExtensionUtils(digCalc).createSubjectKeyIdentifier(publicKeyInfo);
+    }
+
+    /**
+     * Creates the hash value of the authority public key.
+     *
+     * @param publicKey of the authority certificate
+     * @return AuthorityKeyIdentifier hash
+     * @throws OperatorCreationException
+     */
+    private static AuthorityKeyIdentifier createAuthorityKeyId(final PublicKey publicKey)
+            throws OperatorCreationException {
+        final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
+        final DigestCalculator digCalc =
+                new BcDigestCalculatorProvider().get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+
+        return new X509ExtensionUtils(digCalc).createAuthorityKeyIdentifier(publicKeyInfo);
+    }
+
+    public static KeyStore createKeystore(X509Certificate cert, PrivateKey key) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(CERTIFICATE_ALIAS, key, "MINIMAPWD".toCharArray(), new java.security.cert.Certificate[]{cert});
+        return keyStore;
+    }
+}

--- a/src/org/minima/system/network/minidapps/SelfSignedCertGenerator.java
+++ b/src/org/minima/system/network/minidapps/SelfSignedCertGenerator.java
@@ -26,13 +26,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 
-/**
- * Utility class for generating self-signed certificates.
- */
+
 public final class SelfSignedCertGenerator {
 
     public static final String CERTIFICATE_ALIAS = "MINIMA_NODE";
-    public static final String CERTIFICATE_NAME = "minima.keystore";
 
     private SelfSignedCertGenerator() {
     }

--- a/test/org/minima/tests/system/network/minidapps/SelfSignedCertGeneratorTest.java
+++ b/test/org/minima/tests/system/network/minidapps/SelfSignedCertGeneratorTest.java
@@ -1,0 +1,34 @@
+package org.minima.tests.system.network.minidapps;
+
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.junit.Test;
+import org.minima.system.network.minidapps.SelfSignedCertGenerator;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class SelfSignedCertGeneratorTest {
+
+    @Test
+    public void createSelfSignedCertificate() throws CertificateException, CertIOException, OperatorCreationException, NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(4096);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        final X509Certificate cert = SelfSignedCertGenerator.generate(keyPair, "SHA256withRSA", "localhost", 730);
+        assertNull(cert.getKeyUsage());
+        assertNull(cert.getExtendedKeyUsage());
+        assertEquals("X.509", cert.getType());
+        assertEquals("CN=localhost", cert.getSubjectDN().getName());
+        assertEquals(cert.getSubjectDN(), cert.getIssuerDN());
+        assertEquals("SHA256withRSA", cert.getSigAlgName());
+        assertEquals(3, cert.getVersion());
+    }
+}


### PR DESCRIPTION

This PR adds the code required to generate a self signed certificate and configures nanohttpd to use the certificate.

Limitations:
- As the certificate is self signed, you do get a warning about the certificate
- Generates a new certificate each time the minima node is started

Testing:
- Unit test added for ssl certificate generation
- Manually tested on android and pc