### PR TITLE
fix docker run instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The reports can be found at
 For those using Docker, you can try the Minima docker image without compiling the source code:
 ```
 docker pull minimaglobal/minima:tests
-docker run minima:tests
+docker run minimaglobal/minima:tests
 ```
 
 The tests tag maps to the tests github branch.


### PR DESCRIPTION
With current instructions getting error: "repository does not exist or may require 'docker login". This PR fixes that.


```
> docker pull minimaglobal/minima:tests
tests: Pulling from minimaglobal/minima
188c0c94c7c5: Pull complete
8c88a916159e: Pull complete
d27bd97069a2: Pull complete
94c7f23fccd5: Pull complete
ecabffef1343: Pull complete
818c63ae76b8: Pull complete
4f487e9c057f: Pull complete
Digest: sha256:ad8ccbe7d48ae72b649ea98983fabf67734e379bded74c8f14a6027095c43f91
Status: Downloaded newer image for minimaglobal/minima:tests
docker.io/minimaglobal/minima:tests

> docker run minima:tests
Unable to find image 'minima:tests' locally
docker: Error response from daemon: pull access denied for minima, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```