### PR TITLE
ArrayIndexOutOfBoundsException during message processing in TimerProcessor.java

### DIFF
--- a/src/org/minima/utils/messages/TimerProcessor.java
+++ b/src/org/minima/utils/messages/TimerProcessor.java
@@ -32,9 +32,15 @@ public class TimerProcessor implements Runnable {
 	 */
 	private ArrayList<TimerMessage> mTimerMessages;
 	
+	/**
+	 * Synchronization lock for mTimerMessages
+	 */
+	private Object mMessagesLock;
+	
 	private TimerProcessor() {
 		mRunning 		= true;
 		mTimerMessages 	= new ArrayList<TimerMessage>();
+		mMessagesLock	= new Object();
 		
 		mMainThread = new Thread(this);
 		mMainThread.start();
@@ -47,7 +53,7 @@ public class TimerProcessor implements Runnable {
 	}
 	
 	public void PostMessage(TimerMessage zMessage) {
-		synchronized (mTimerMessages) {
+		synchronized (mMessagesLock) {
 			mTimerMessages.add(zMessage);
 		}
 	}
@@ -57,7 +63,7 @@ public class TimerProcessor implements Runnable {
 		while(mRunning) {
 			
 			//Check the stack for messages..
-			synchronized (mTimerMessages) {
+			synchronized (mMessagesLock) {
 				//New list to store the ongoing timers
 				ArrayList<TimerMessage> newlist = new ArrayList<TimerMessage>();
 				


### PR DESCRIPTION
Due to concurrency issue with mTimerMessages object swap with newList, while another thread is waiting inside PostMessage call, ArrayIndexOutOfBoundsException is fired. Execution stops after that.

Minima @ 18/02/2022 08:42:38 [82.8 MB] : [+] Setting My IP: 195.216.206.2
Minima @ 18/02/2022 08:42:39 [82.8 MB] : [+] Connected to the blockchain Initial Block Download received. size:5 bytes blocks:0
Minima @ 18/02/2022 08:42:48 [83.8 MB] : Warning : Attempting to connect to already connected host 45.95.203.53:9001
Minima @ 18/02/2022 09:08:11 [203.3 MB] : [+] Connected to the blockchain Initial Block Download received. size:5 bytes blocks:0
Minima @ 18/02/2022 09:41:54 [72.9 MB] : MESSAGE PROCESSING ERROR @ MAIN_PULSE
Minima @ 18/02/2022 09:41:54 [72.9 MB] : java.lang.ArrayIndexOutOfBoundsException: 10
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      java.util.ArrayList.add(Unknown Source)
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      org.minima.utils.messages.TimerProcessor.PostMessage(TimerProcessor.java:51)
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      org.minima.utils.messages.MessageProcessor.PostTimerMessage(MessageProcessor.java:83)
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      org.minima.system.Main.processMessage(Main.java:410)
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      org.minima.utils.messages.MessageProcessor.run(MessageProcessor.java:106)
Minima @ 18/02/2022 09:41:54 [76.0 MB] :      java.lang.Thread.run(Unknown Source)
Exception in thread "Thread-1" java.lang.NullPointerException
        at org.minima.utils.messages.TimerProcessor.run(TimerProcessor.java:70)
        at java.lang.Thread.run(Unknown Source)