### PR TITLE
Tweaks to P2P System

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       resources:
         limits:
           cpus: '0.25'
-          memory: 300M
+          memory: 1000M
   minima_no_p2p:
     image: minima:latest
     command: -test -daemon -nop2p -connect minima_one:9001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 services:
   minima_one:
     image: minima:latest
-    command: -daemon -genesis -automine -noconnect -test -port 9001 -rpc 9002 -rpcenable -clean 
+    command: -daemon -genesis -noconnect -test -port 9001 -rpc 9002 -rpcenable
     networks:
       minima_testnet:
         aliases:
@@ -19,11 +19,11 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 500M
+          memory: 1000M
 
   minima_peer:
     image: minima:latest
-    command: -daemon -test -port 9121 -p2pnode minima_one:9001 -clean
+    command: -daemon -test -port 9121 -p2pnode minima_one:9001
     networks:
       minima_testnet:
         aliases:
@@ -34,10 +34,11 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 500M
+          memory: 1000M
+
   minima_client:
     image: minima:latest
-    command: -test -daemon -isclient -p2pnode minima_one:9001 -clean
+    command: -test -daemon -isclient -p2pnode minima_one:9001
     networks:
       minima_testnet:
         aliases:
@@ -51,7 +52,7 @@ services:
           memory: 300M
   minima_no_p2p:
     image: minima:latest
-    command: -test -daemon -nop2p -connect minima_one:9001  -clean
+    command: -test -daemon -nop2p -connect minima_one:9001
     networks:
       minima_testnet:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,4 +63,4 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 500M
+          memory: 1000M

--- a/src/org/minima/system/network/minima/NIOMessage.java
+++ b/src/org/minima/system/network/minima/NIOMessage.java
@@ -453,6 +453,7 @@ public class NIOMessage implements Runnable {
 					MinimaLogger.log(mClientUID+" Error null client on P2P NIOMessage..");
 					return;
 				}
+				NIOClientInfo clientInfo = new NIOClientInfo(nioclient, true);
 				
 				//Convert to JSON
 				JSONObject json = (JSONObject) new JSONParser().parse(msg.toString());
@@ -466,6 +467,7 @@ public class NIOMessage implements Runnable {
 					//Post with delay
 					TimerMessage p2p = new TimerMessage(10000, P2PFunctions.P2P_MESSAGE);
 					p2p.addString("uid", mClientUID);
+					p2p.addObject("client", clientInfo);
 					p2p.addObject("message", json);
 					p2pmanager.PostTimerMessage(p2p);
 					
@@ -473,6 +475,7 @@ public class NIOMessage implements Runnable {
 					//Post directly
 					Message p2p = new Message(P2PFunctions.P2P_MESSAGE);
 					p2p.addString("uid", mClientUID);
+					p2p.addObject("client", clientInfo);
 					p2p.addObject("message", json);
 					p2pmanager.PostMessage(p2p);
 					

--- a/src/org/minima/system/network/p2p/P2PManager.java
+++ b/src/org/minima/system/network/p2p/P2PManager.java
@@ -258,7 +258,11 @@ public class P2PManager extends MessageProcessor {
                     // Loop is set to be quite fast at this point to ensure we connect to the network
                     InetSocketAddress connectionAddress = (InetSocketAddress) state.getKnownPeers().toArray()[rand.nextInt(state.getKnownPeers().size())];
                     sendMsgs.add(new Message(P2PManager.P2P_SEND_CONNECT).addObject(ADDRESS_LITERAL, connectionAddress));
-                } else if (state.getOutLinks().size() < 2) {
+
+                // If there are fewer connections than the min number of connections connect using the peers list
+                // Min number of connections is the param clients use, so clients will always connect using the peers list
+                // Then be load balanced
+                } else if (state.getOutLinks().size() < P2PParams.MIN_NUM_CONNECTIONS) {
                     InetSocketAddress connectionAddress = (InetSocketAddress) state.getKnownPeers().toArray()[rand.nextInt(state.getKnownPeers().size())];
                     sendMsgs.add(new Message(P2PManager.P2P_SEND_CONNECT).addObject(ADDRESS_LITERAL, connectionAddress));
                 } else if (state.isAcceptingInLinks()) {
@@ -278,9 +282,7 @@ public class P2PManager extends MessageProcessor {
                 }
             }
         }
-//        JSONObject status = getStatus();
-//        status.remove("p2p_state");
-//        MinimaLogger.log(status.toString());
+
         return sendMsgs;
     }
 
@@ -385,8 +387,6 @@ public class P2PManager extends MessageProcessor {
         P2PDB p2pdb = MinimaDB.getDB().getP2PDB();
         p2pdb.setVersion();
         p2pdb.setPeersList(new ArrayList<>(state.getKnownPeers()));
-
-        //I save the DB.. you don't do it..!
 
         //And finish with..
         stopMessageProcessor();

--- a/src/org/minima/system/network/p2p/P2PManager.java
+++ b/src/org/minima/system/network/p2p/P2PManager.java
@@ -41,7 +41,6 @@ public class P2PManager extends MessageProcessor {
     public static final String P2P_SEND_MSG_TO_ALL = "P2P_SEND_MSG_TO_ALL";
     public static final String P2P_SEND_CONNECT = "P2P_SEND_CONNECT";
     public static final String P2P_SEND_DISCONNECT = "P2P_SEND_DISCONNECT";
-    public static final String P2P_METRICS = "P2P_METRICS";
 
     public static final String P2P_SAVE_DATA = "P2P_SAVE_DATA";
 
@@ -63,6 +62,8 @@ public class P2PManager extends MessageProcessor {
         PostTimerMessage(new TimerMessage(P2PParams.SAVE_DATA_DELAY, P2P_SAVE_DATA));
         PostTimerMessage(new TimerMessage(20_000, P2P_UPDATE_HASH_RATE));
     }
+
+
 
     protected static List<Message> processWalkLinksMsg(JSONObject zMessage, NIOClientInfo clientInfo, P2PState state) {
         P2PWalkLinks p2pWalkLinks = P2PWalkLinks.readFromJSON(zMessage);
@@ -312,7 +313,6 @@ public class P2PManager extends MessageProcessor {
         List<Message> sendMsgs = new ArrayList<>();
         if (zMessage.isMessageType(P2PFunctions.P2P_INIT)) {
             sendMsgs.addAll(init(state));
-            PostTimerMessage(new TimerMessage(P2PParams.METRICS_DELAY, P2P_METRICS));
         } else if (zMessage.isMessageType(P2PFunctions.P2P_SHUTDOWN)) {
             shutdown();
         } else if (zMessage.isMessageType(P2P_SAVE_DATA)) {
@@ -372,10 +372,6 @@ public class P2PManager extends MessageProcessor {
 
             state.setDeviceHashRate(megspeed);
             PostTimerMessage(new TimerMessage(P2PParams.HASH_RATE_UPDATE_DELAY, P2P_UPDATE_HASH_RATE));
-        } else if (zMessage.isMessageType(P2P_METRICS)) {
-            PostTimerMessage(new TimerMessage(P2PParams.METRICS_DELAY, P2P_METRICS));
-            RPCClient.sendPOST(P2PParams.METRICS_URL, state.toJson().toString(), "application/json");
-            MinimaLogger.log("[+] Metrics sent");
         }
         sendMessages(sendMsgs);
     }

--- a/src/org/minima/system/network/p2p/P2PState.java
+++ b/src/org/minima/system/network/p2p/P2PState.java
@@ -234,20 +234,6 @@ public class P2PState {
         return json;
     }
 
-    private JSONArray addressListToJSONArray(ArrayList<InetSocketAddress> addresses) {
-        JSONArray links = new JSONArray();
-        if (!addresses.isEmpty()) {
-            for (InetSocketAddress inetSocketAddress : addresses) {
-                if (inetSocketAddress != null) {
-                    links.add(inetSocketAddress.toString().replaceAll("/", ""));
-                } else {
-                    links.add("nullAddress:9001");
-                }
-            }
-        }
-        return links;
-    }
-
     public boolean isNoConnect() {
         return noConnect;
     }

--- a/src/org/minima/system/network/p2p/SwapLinksFunctions.java
+++ b/src/org/minima/system/network/p2p/SwapLinksFunctions.java
@@ -105,6 +105,7 @@ public class SwapLinksFunctions {
             NIOClientInfo minimaClient = UtilFuncs.getClientFromInetAddress(nextHop, state);
             P2PWalkLinks walkLinks = new P2PWalkLinks(true, false, minimaClient.getUID());
             walkLinks.setClientWalk(true);
+            // Send out multiple load balance request messages if node is highly overloaded
             int multipleOverMax = state.getInLinks().size() / state.getMaxNumP2PConnections();
             for (int i=0; i < multipleOverMax; i++) {
                 msgs.add(new Message(P2PManager.P2P_SEND_MSG).addString("uid", minimaClient.getUID()).addObject("json", walkLinks.toJson()));

--- a/src/org/minima/system/network/p2p/SwapLinksFunctions.java
+++ b/src/org/minima/system/network/p2p/SwapLinksFunctions.java
@@ -54,24 +54,6 @@ public class SwapLinksFunctions {
         } else {
             state.getNoneP2PLinks().put(uid, new InetSocketAddress(info.getHost(), info.getPort()));
         }
-        
-//        if (incoming) {
-//            InetSocketAddress incomingAddress = new InetSocketAddress(info.getHost(), 0);
-//
-//            if(info.getHost().equals("127.0.0.1")) {
-//            	//It's an SSH Forward address with no HOST set..
-//            	state.getNoneP2PLinks().put(uid, new InetSocketAddress(info.getHost(), 0));
-//
-//            }else {
-//                if (state.getNoneP2PLinks().containsValue(incomingAddress) && !info.isMaximaClient()) {
-//	                msgs.add(new Message(P2PManager.P2P_SEND_DISCONNECT).addString("uid", uid));
-//	                sendMessages = false;
-//	            }
-//	            state.getNoneP2PLinks().put(uid, new InetSocketAddress(info.getHost(), 0));
-//            }
-//        } else {
-//            state.getNoneP2PLinks().put(uid, new InetSocketAddress(info.getHost(), info.getPort()));
-//        }
 
         if (sendMessages) {
             P2PGreeting greeting = new P2PGreeting(state);

--- a/src/org/minima/system/network/p2p/SwapLinksFunctions.java
+++ b/src/org/minima/system/network/p2p/SwapLinksFunctions.java
@@ -126,9 +126,10 @@ public class SwapLinksFunctions {
         state.getKnownPeers().addAll(state.getOutLinks().values());
     }
 
-    public static boolean processGreeting(P2PState state, P2PGreeting greeting, String uid, NIOClientInfo client, boolean noconnect) {
+    public static boolean processGreeting(P2PState state, P2PGreeting greeting, NIOClientInfo client, boolean noconnect) {
 
         if (client != null) {
+            String uid = client.getUID();
             String host = client.getHost();
             int port = greeting.getMyMinimaPort();
             InetSocketAddress minimaAddress = new InetSocketAddress(host, port);
@@ -140,7 +141,9 @@ public class SwapLinksFunctions {
             //The NIOClient has received a P2Pgreeting.. Check if NULL or Tests fail
             if(Main.getInstance() != null) {
 	            NIOClient nioclient = Main.getInstance().getNIOManager().getNIOServer().getClient(uid);
-	            nioclient.setReceivedP2PGreeting();
+                if (nioclient != null){
+	                nioclient.setReceivedP2PGreeting();
+                }
             }
 
             if (greeting.isAcceptingInLinks()) {
@@ -156,7 +159,6 @@ public class SwapLinksFunctions {
                     state.getOutLinks().put(uid, minimaAddress);
                     if (state.getOutLinks().size() > state.getMaxNumP2PConnections()) {
                         P2PFunctions.disconnect(uid);
-                        MinimaLogger.log("[-] Too many outgoing connections, disconnecting");
                     }
                 }
 
@@ -173,7 +175,7 @@ public class SwapLinksFunctions {
                 state.getNotAcceptingConnP2PLinks().put(uid, minimaAddress);
             }
         } else {
-            MinimaLogger.log("[-] ERROR Client is null UID:"+uid+" when processing greeting: " + greeting.toJson());
+            MinimaLogger.log("[-] ERROR Client is null when processing greeting: " + greeting.toJson());
         }
         return noconnect;
     }
@@ -197,15 +199,8 @@ public class SwapLinksFunctions {
             state.getKnownPeers().remove(state.getMyMinimaAddress());
             MinimaLogger.log("[+] Setting My IP: " + hostIP);
 
-//            //Set this globally..
-//            if(!GeneralParams.IS_HOST_SET) {
-//            	GeneralParams.IS_HOST_SET = true;
-//            	GeneralParams.MINIMA_HOST = hostIP;
-//            }
-
-        } else {
-            MinimaLogger.log("[-] WARNING : Failed to set my ip. Secrets do not match - could be a delay. MySecret: " + state.getIpReqSecret() + " Received secret: " + secret);
         }
+
     }
 
     public static List<Message> joinScaleOutLinks(P2PState state, int targetNumLinks, ArrayList<NIOClientInfo> clients) {

--- a/src/org/minima/system/network/p2p/SwapLinksFunctions.java
+++ b/src/org/minima/system/network/p2p/SwapLinksFunctions.java
@@ -105,7 +105,10 @@ public class SwapLinksFunctions {
             NIOClientInfo minimaClient = UtilFuncs.getClientFromInetAddress(nextHop, state);
             P2PWalkLinks walkLinks = new P2PWalkLinks(true, false, minimaClient.getUID());
             walkLinks.setClientWalk(true);
-            msgs.add(new Message(P2PManager.P2P_SEND_MSG).addString("uid", minimaClient.getUID()).addObject("json", walkLinks.toJson()));
+            int multipleOverMax = state.getInLinks().size() / state.getMaxNumP2PConnections();
+            for (int i=0; i < multipleOverMax; i++) {
+                msgs.add(new Message(P2PManager.P2P_SEND_MSG).addString("uid", minimaClient.getUID()).addObject("json", walkLinks.toJson()));
+            }
         }
         return msgs;
     }

--- a/src/org/minima/system/network/p2p/WalkLinksFuncs.java
+++ b/src/org/minima/system/network/p2p/WalkLinksFuncs.java
@@ -248,8 +248,9 @@ public class WalkLinksFuncs {
 
         List<Message> retMessages = new ArrayList<>();
         if (state.getNotAcceptingConnP2PLinks().size() > state.getMaxNumNoneP2PConnections()) {
-            int numClientsToSend = state.getMaxNumNoneP2PConnections() / 2;
-            int numSwaps = Math.min(numClientsToSend, maxClientsCanReceive);
+            // Either maxClientsCanReceive or 1/2 MaxNoneP2pConnections a node can handle number of swaps
+            // Using 1/2 MaxNoneP2pConnections to prevent essential just swapping clients between nodes when not needed
+            int numSwaps = Math.min(maxClientsCanReceive, state.getMaxNumNoneP2PConnections() / 2);
             for (int i = 0; i < numSwaps; i++) {
                 // Send a DOSWAP message to numSwaps clients
                 List<String> nonP2PLinkUIDs = new ArrayList<>(state.getNotAcceptingConnP2PLinks().keySet());

--- a/src/org/minima/system/network/p2p/WalkLinksFuncs.java
+++ b/src/org/minima/system/network/p2p/WalkLinksFuncs.java
@@ -249,7 +249,7 @@ public class WalkLinksFuncs {
         List<Message> retMessages = new ArrayList<>();
         if (state.getNotAcceptingConnP2PLinks().size() > state.getMaxNumNoneP2PConnections()) {
             int numClientsToSend = state.getMaxNumNoneP2PConnections() / 2;
-            int numSwaps = Math.min(Math.min(numClientsToSend, maxClientsCanReceive), state.getNotAcceptingConnP2PLinks().size());
+            int numSwaps = Math.min(numClientsToSend, maxClientsCanReceive);
             for (int i = 0; i < numSwaps; i++) {
                 // Send a DOSWAP message to numSwaps clients
                 List<String> nonP2PLinkUIDs = new ArrayList<>(state.getNotAcceptingConnP2PLinks().keySet());

--- a/src/org/minima/system/network/p2p/params/P2PTestParams.java
+++ b/src/org/minima/system/network/p2p/params/P2PTestParams.java
@@ -14,13 +14,13 @@ public class P2PTestParams {
     /**
      * Desired number of client (nodes that can't accept inbound connections) to maintain
      */
-    public static int TGT_NUM_NONE_P2P_LINKS = 5;
+    public static int TGT_NUM_NONE_P2P_LINKS = 2;
 
     /**
      * Desired number of connections clients should maintain
-     * For testing this number is set higher to test load balancing
+     * This must be less than TGT_NUM_LINKS or it will break the p2p logic
      */
-    public static int MIN_NUM_CONNECTIONS = 10;
+    public static int MIN_NUM_CONNECTIONS = 2;
 
     /**
      * Time between P2P system assessing its state in milliseconds
@@ -30,8 +30,8 @@ public class P2PTestParams {
     /**
      * Time between updating the device hash_rate in milliseconds
      */
-    //                                         M    S    millis
-    public static int HASH_RATE_UPDATE_DELAY = 5 * 60 * 1000;
+    //                                         S    millis
+    public static int HASH_RATE_UPDATE_DELAY = 60 * 1000;
 
     /**
      * Max additional ms to add to loop delay (mostly useful during testing to ensure all nodes
@@ -78,6 +78,7 @@ public class P2PTestParams {
         P2PParams.METRICS_DELAY = METRICS_DELAY;
         P2PParams.METRICS_URL = METRICS_URL;
         P2PParams.SAVE_DATA_DELAY = SAVE_DATA_DELAY;
+        P2PParams.HASH_RATE_UPDATE_DELAY = HASH_RATE_UPDATE_DELAY;
     }
 
 

--- a/test/org/minima/system/network/p2p/SwapLinksFunctionsTest.java
+++ b/test/org/minima/system/network/p2p/SwapLinksFunctionsTest.java
@@ -68,7 +68,7 @@ public class SwapLinksFunctionsTest extends TestCase {
         P2PGreeting greeting = new P2PGreeting(greetingState);
 
         P2PState state = QuickState.stateNoneP2PLink(1, 9001);
-        SwapLinksFunctions.processGreeting(state, greeting, "noneP2PUID1", client, true);
+        SwapLinksFunctions.processGreeting(state, greeting, client, true);
 
         assertFalse(state.getInLinks().isEmpty());
         assertTrue(state.getNoneP2PLinks().isEmpty());
@@ -83,7 +83,7 @@ public class SwapLinksFunctionsTest extends TestCase {
         P2PGreeting greeting = new P2PGreeting(greetingState);
 
         P2PState state = QuickState.stateNoneP2PLink(1, 9001);
-        SwapLinksFunctions.processGreeting(state, greeting, "noneP2PUID1", client, true);
+        SwapLinksFunctions.processGreeting(state, greeting, client, true);
 
         assertFalse(state.getOutLinks().isEmpty());
         assertTrue(state.getNoneP2PLinks().isEmpty());


### PR DESCRIPTION
- Client load balancing more aggressive. We now send 1 message for each multiple over the desired client node count
- Tweaked number of clients load balanced in one request
- Reduced the number of connections to two nodes from the peers list then use walk links to add outlinks
- Tweaked p2p parameters