### PR TITLE
fix tranactions with floating input getting stuck in mempool

### DIFF
--- a/src/org/minima/system/brains/TxPoWChecker.java
+++ b/src/org/minima/system/brains/TxPoWChecker.java
@@ -598,18 +598,18 @@ public class TxPoWChecker {
 		
 		//Get all the coins..
 		if(!zTxPoW.getTransaction().isEmpty()) {
-			ArrayList<Coin> inputs = zTxPoW.getTransaction().getAllInputs();
-			for(Coin cc : inputs) {
-				if(txpdb.checkMempoolCoins(cc.getCoinID())) {
+			ArrayList<CoinProof> proofs = zTxPoW.getWitness().getAllCoinProofs();
+			for(CoinProof cp : proofs) {
+				if(txpdb.checkMempoolCoins(cp.getCoin().getCoinID())) {
 					return true;
 				}
 			}
 		}
 		
 		if(!zTxPoW.getBurnTransaction().isEmpty()) {
-			ArrayList<Coin> inputs = zTxPoW.getBurnTransaction().getAllInputs();
-			for(Coin cc : inputs) {
-				if(txpdb.checkMempoolCoins(cc.getCoinID())) {
+			ArrayList<CoinProof> proofs = zTxPoW.getBurnWitness().getAllCoinProofs();
+			for(CoinProof cp : proofs) {
+				if(txpdb.checkMempoolCoins(cp.getCoin().getCoinID())) {
 					return true;
 				}
 			}


### PR DESCRIPTION
by checking the coin id from the mmr proofs, not from inputs (where floating inputs have coinid of 0x01)