### PR TITLE
parse txnstate value as string even if it looks like a valid JSON array

### DIFF
--- a/src/org/minima/system/commands/Command.java
+++ b/src/org/minima/system/commands/Command.java
@@ -507,23 +507,21 @@ public abstract class Command {
 				comms.getParams().put(name, json);
 			
 			}else if(value.startsWith("[") && value.endsWith("]")) {
-				
+
+				//Is this a state variable
+				if(command.equals("txnstate")) {
+
+					//Could be a String variable.. add normal String parameter to..
+					comms.getParams().put(name, value);
+
+					continue;
+				}
 				//It's a JSONArray..!
 				JSONArray json = null;
 				try {
 					json = (JSONArray) new JSONParser().parse(value);
 				} catch (ParseException e) {
-					
-					//Is this a state variable
-					if(command.equals("txnstate")) {
-						
-						//Could be a String variable.. add normal String parameter to..
-						comms.getParams().put(name, value);
-						
-						continue;
-					}
-					
-					//Otherwise is just a broken JSONArray
+
 					return new missingcmd(command,"Invalid JSON parameter for "+command+" @ "+token+" "+e.toString());
 				}
 				


### PR DESCRIPTION
Fix error when the txnstate value is interpreted as a JSON array (e.g. a number in bracket to turn it into a string: [123]) and throwing this:
```
ClassCastException: class org.minima.utils.json.JSONArray cannot be cast to class java.lang.String
org.minima.system.commands.Command.getParam(Command.java:205)
org.minima.system.commands.txn.txnstate.runCommand(txnstate.java:59)
```