### PR TITLE
content type header for wasm

### DIFF
--- a/src/org/minima/utils/MiniFile.java
+++ b/src/org/minima/utils/MiniFile.java
@@ -464,6 +464,8 @@ public class MiniFile {
 			return "audio/mp3";
 		}else if(ending.equals("wav")) {
 			return "audio/wav";
+		}else if(ending.equals("wasm")) {
+			return "application/wasm";
 		}
 		
 		return "text/plain";


### PR DESCRIPTION
Set correct Content-type header for .wasm files, otherwise browser rejects them with:
`Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'`