### PR TITLE
fix: reverse proxy compatibility (header case + port 0 in mds.js)

### DIFF
--- a/mds/code/basic/mds.js
+++ b/mds/code/basic/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/blockscan/mds.js
+++ b/mds/code/blockscan/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/bonds/mds.js
+++ b/mds/code/bonds/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/bridge/mds.js
+++ b/mds/code/bridge/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/cevt/payment/mds.js
+++ b/mds/code/cevt/payment/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/cevt/terminal/mds.js
+++ b/mds/code/cevt/terminal/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/chainmail/miniweb/libs/mds.js
+++ b/mds/code/chainmail/miniweb/libs/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/chatter/mds.js
+++ b/mds/code/chatter/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/coincheck/mds.js
+++ b/mds/code/coincheck/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/dexxed/mds.js
+++ b/mds/code/dexxed/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/ethwallettest/mds.js
+++ b/mds/code/ethwallettest/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/files/mds.js
+++ b/mds/code/files/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/htlc/mds.js
+++ b/mds/code/htlc/mds.js
@@ -83,7 +83,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/htlc/rescue/mds.js
+++ b/mds/code/htlc/rescue/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/linux/mds.js
+++ b/mds/code/linux/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/lotto/mds.js
+++ b/mds/code/lotto/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/maxchat/mds.js
+++ b/mds/code/maxchat/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/maxsolo/mds.js
+++ b/mds/code/maxsolo/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/mdsapi/mds.js
+++ b/mds/code/mdsapi/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/minifs/mds.js
+++ b/mds/code/minifs/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/minihub/mds.js
+++ b/mds/code/minihub/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/minimaide/js/mds.js
+++ b/mds/code/minimaide/js/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/minimaide/mds.js
+++ b/mds/code/minimaide/mds.js
@@ -72,10 +72,18 @@ var MDS = {
 		//The ports..
 		var mainport 	= port+1;
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+		}
 		MDS.log("MDS FILEHOST  : "+MDS.filehost);
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/miniweb/mds.js
+++ b/mds/code/miniweb/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/miniweb/root/miniweb/libs/mds.js
+++ b/mds/code/miniweb/root/miniweb/libs/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/miniweb/root/miniweb/mds.js
+++ b/mds/code/miniweb/root/miniweb/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/mns/mds.js
+++ b/mds/code/mns/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/mnsweb/mds.js
+++ b/mds/code/mnsweb/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/nftmarket/mds.js
+++ b/mds/code/nftmarket/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/paychecker/mds.js
+++ b/mds/code/paychecker/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/publicwallet/mds.js
+++ b/mds/code/publicwallet/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/scriptide/js/mds.js
+++ b/mds/code/scriptide/js/mds.js
@@ -74,8 +74,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/shoutout/mds.js
+++ b/mds/code/shoutout/mds.js
@@ -68,8 +68,14 @@ var MDS = {
       MDS.log("No MiniDAPP UID specified.. using test value");
     }
 
-    MDS.filehost = "https://" + host + ":" + port + "/";
-    MDS.mainhost = "https://" + host + ":" + port + "/mdscommand_/";
+    //Are we on a standard port (443/80)?
+    if(port == 0){
+      MDS.filehost = "https://" + host + "/";
+      MDS.mainhost = "https://" + host + "/mdscommand_/";
+    }else{
+      MDS.filehost = "https://" + host + ":" + port + "/";
+      MDS.mainhost = "https://" + host + ":" + port + "/mdscommand_/";
+    }
     MDS.log("MDS HOST  : " + MDS.filehost);
 
     //Store this for poll messages

--- a/mds/code/sqlbench/mds.js
+++ b/mds/code/sqlbench/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/synccmd/mds.js
+++ b/mds/code/synccmd/mds.js
@@ -71,7 +71,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/terminal-1.0/mds.js
+++ b/mds/code/terminal-1.0/mds.js
@@ -84,7 +84,11 @@ var MDS = {
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
 		//MDS.mainhost 	= "https://"+host+":"+mainport+"/";
-		MDS.mainhost 	= "https://"+host+":"+port+"/mdscommand_/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/terminal-2.1.0/assets/mds.js
+++ b/mds/code/terminal-2.1.0/assets/mds.js
@@ -83,7 +83,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/terminal-2.1.0/mds.js
+++ b/mds/code/terminal-2.1.0/mds.js
@@ -83,7 +83,11 @@ var MDS = {
 		
 		MDS.log("MDS FILEHOST  : https://"+host+":"+port+"/");
 		
-		MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		if(port == 0){
+			MDS.mainhost 	= "https://"+host+"/";
+		}else{
+			MDS.mainhost 	= "https://"+host+":"+mainport+"/";
+		}
 		MDS.log("MDS MAINHOST : "+MDS.mainhost);
 		
 		//Store this for poll messages

--- a/mds/code/thunder/js/mds.js
+++ b/mds/code/thunder/js/mds.js
@@ -75,8 +75,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/timestamp/mds.js
+++ b/mds/code/timestamp/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/mds/code/vault/mds.js
+++ b/mds/code/vault/mds.js
@@ -69,8 +69,14 @@ var MDS = {
 			MDS.log("No MiniDAPP UID specified.. using test value");
 		}
 		
-		MDS.filehost = "https://"+host+":"+port+"/";
-		MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		//Are we on a standard port (443/80)?
+		if(port == 0){
+			MDS.filehost = "https://"+host+"/";
+			MDS.mainhost = "https://"+host+"/mdscommand_/";
+		}else{
+			MDS.filehost = "https://"+host+":"+port+"/";
+			MDS.mainhost = "https://"+host+":"+port+"/mdscommand_/";
+		}
 		MDS.log("MDS HOST  : "+MDS.filehost);
 		
 		//Store this for poll messages

--- a/src/org/minima/system/mds/MDSFileHandler.java
+++ b/src/org/minima/system/mds/MDSFileHandler.java
@@ -133,7 +133,13 @@ public class MDSFileHandler implements Runnable {
 				if(start != -1) {
 					String name  = input.substring(0,start).trim();
 					String value = input.substring(start+1).trim();
-					
+
+					//Normalize header name to be case-insensitive
+					//HTTP/1.1 headers are case-insensitive (RFC 7230)
+					//HTTP/2 mandates lowercase headers (RFC 7540)
+					//Reverse proxies like Traefik may send lowercase headers
+					name = normalizeHeaderName(name);
+
 					//Put it in the headers
 					allheaders.put(name, value);
 				}
@@ -819,5 +825,38 @@ public class MDSFileHandler implements Runnable {
 		is.close();
 		
 		return new String(file, MiniString.MINIMA_CHARSET);
+	}
+
+	/**
+	 * Normalize HTTP header names to their canonical form.
+	 * HTTP/1.1 headers are case-insensitive (RFC 7230 Section 3.2),
+	 * and HTTP/2 mandates lowercase headers (RFC 7540 Section 8.1.2).
+	 *
+	 * Reverse proxies (Traefik, nginx, HAProxy) may forward headers
+	 * in lowercase when proxying HTTP/2 to HTTP/1.1 backends.
+	 * This ensures headers like "content-length" are normalized to
+	 * "Content-Length" for consistent internal lookups.
+	 */
+	private static String normalizeHeaderName(String name) {
+		if(name == null || name.isEmpty()) {
+			return name;
+		}
+
+		//Convert to canonical HTTP header case: first letter and letter after '-' uppercase
+		StringBuilder sb = new StringBuilder(name.length());
+		boolean capitalizeNext = true;
+		for(int i = 0; i < name.length(); i++) {
+			char c = name.charAt(i);
+			if(c == '-') {
+				sb.append(c);
+				capitalizeNext = true;
+			} else if(capitalizeNext) {
+				sb.append(Character.toUpperCase(c));
+				capitalizeNext = false;
+			} else {
+				sb.append(Character.toLowerCase(c));
+			}
+		}
+		return sb.toString();
 	}
 }


### PR DESCRIPTION
## Problem

When Minima's MDS (MiniDapp System) runs behind a reverse proxy like **Traefik**, **nginx**, or **HAProxy**, two bugs prevent MiniDapps from working:

### Bug 1: Case-sensitive HTTP header parsing (`MDSFileHandler.java`)

All POST requests fail with **"Connection failed: Your session is invalid"**.

`MDSFileHandler.java` stores HTTP headers with their original case but looks them up with exact case `"Content-Length"`. Per **RFC 7230 §3.2**, HTTP/1.1 headers are case-insensitive, and per **RFC 7540 §8.1.2**, HTTP/2 mandates lowercase. When a reverse proxy forwards `content-length` (lowercase):

1. `allheaders.get("Content-Length")` → `null`
2. `Integer.parseInt(null)` → `NumberFormatException`
3. Caught by generic `catch(Exception)` → returns `invalid.html`
4. MiniDapp JS does `JSON.parse(html)` → **"Connection failed"**

### Bug 2: `ERR_UNSAFE_PORT` in MiniDapp `mds.js` copies

When accessing via standard HTTPS (port 443), `window.location.port` returns `""`. `Math.floor("")` evaluates to `0`, producing URLs like `https://host:0/mdscommand_/...`. Browsers block port 0 → `ERR_UNSAFE_PORT` → black screen.

The main `mds/mds.js` already has the fix (`if(port == 0)` check), but **41 copies** in `mds/code/*/mds.js` still had the old code.

## Fixes

### Commit 1: `MDSFileHandler.java`

Added `normalizeHeaderName()` that converts HTTP header names to canonical form (`content-length` → `Content-Length`) when parsing. Follows standard HTTP convention: capitalize first letter and every letter after a hyphen.

### Commit 2: `mds/code/*/mds.js` (41 files)

Added `if(port == 0)` check to omit the port from URLs when running on standard ports (443/80), matching the fix already present in the main `mds/mds.js`.

## Testing

- Direct access (no proxy) — ✅ works as before
- Behind Traefik 3.x with HTTP/2 → HTTP/1.1 — ✅ both bugs fixed
- `curl` with lowercase headers — ✅ handled correctly
- Standard HTTPS port (443) — ✅ no more ERR_UNSAFE_PORT

## Files Changed

- `src/org/minima/system/mds/MDSFileHandler.java` — Header name normalization
- `mds/code/*/mds.js` (41 files) — Port 0 handling